### PR TITLE
Add Picasso Markets (PICASSO) to information_markets_projects.json

### DIFF
--- a/information_markets/information_markets_projects.json
+++ b/information_markets/information_markets_projects.json
@@ -1,5 +1,12 @@
 [
     {
+        "ticker": "PICASSO",
+        "remarks": {
+            "display_ticker": "PICASSO",
+            "fullname": "Picasso Markets"
+        }
+    },
+    {
         "ticker": "POLYMARKET",
         "remarks": {
             "display_ticker": "POLYMARKET",


### PR DESCRIPTION
Adds Picasso Markets (PICASSO) to the Information Markets list.

display_ticker = PICASSO
fullname = Picasso Markets

Context: @picassomarkets on X

