### PR TITLE
Add Belief Market to information markets projects list

### DIFF
--- a/information_markets/information_markets_projects.json
+++ b/information_markets/information_markets_projects.json
@@ -187,5 +187,12 @@
             "display_ticker": "FIREPLACE",
             "fullname": "fireplace"
         }
+    },
+    {
+        "ticker": "BELIEFMARKET",
+        "remarks": {
+            "display_ticker": "BELIEFMARKET",
+            "fullname": "Belief Market"
+        }
     }
 ]


### PR DESCRIPTION
  About Belief Market:
  - Social prediction game where winning equals being the most popular, not the most
  correct
  - Users back beliefs with capital in markets shaped by culture and collective
  sentiment
  - Winners determined by majority pot (highest total stake), not accuracy
  - Website: https://www.belief.market/
  - App: https://app.belief.market/