### PR TITLE
Remove GENSYN and UFO from PreTGE list

### DIFF
--- a/PreTGE_Project/PreTGE_Project.json
+++ b/PreTGE_Project/PreTGE_Project.json
@@ -1,13 +1,5 @@
 [
   {
-    "ticker": "UFO",
-    "remarks": {
-      "display_ticker": "SPACE",
-      "fullname": "Space",
-      "twitter_handle": "intodotspace"
-    }
-  },
-  {
     "ticker": "BASE",
     "remarks": {
       "display_ticker": "BASE",
@@ -1213,14 +1205,6 @@
       "display_ticker": "COMMONWARE",
       "fullname": "commonware",
       "twitter_handle": "commonwarexyz"
-    }
-  },
-  {
-    "ticker": "GENSYN",
-    "remarks": {
-      "display_ticker": "GENSYN",
-      "fullname": "gensyn",
-      "twitter_handle": "gensynai"
     }
   },
   {


### PR DESCRIPTION
## Summary
- Remove **GENSYN** and **UFO** from `PreTGE_Project.json` as both projects have completed their TGE (confirmed via CoinGecko `preview_listing=false`)

## Files Changed
- `PreTGE_Project/PreTGE_Project.json` (removed 2 entries, 182 remaining)