### PR TITLE
[codex] Add KiiChain Pre-TGE project

### DIFF
--- a/PreTGE_Project/PreTGE_Project.json
+++ b/PreTGE_Project/PreTGE_Project.json
@@ -1374,5 +1374,13 @@
             "fullname": "HOOLI",
             "twitter_handle": "mypethooligan"
         }
+    },
+    {
+        "ticker": "KII",
+        "remarks": {
+            "display_ticker": "KII",
+            "fullname": "KiiChain",
+            "twitter_handle": "KiiChainio"
+        }
     }
 ]


### PR DESCRIPTION
## Summary

- Add KiiChain to the Pre-TGE projects list with ticker `KII`.
- Include display ticker, full name, and X/Twitter handle per the contribution README format.

## Validation

- Parsed `PreTGE_Project/PreTGE_Project.json` locally as JSON.
- Confirmed exactly one `KII` entry exists after the change.