### PR TITLE
feat(vc): add vc_firms.json with display metadata for 54 referenced firms

### DIFF
--- a/vc/README.md
+++ b/vc/README.md
@@ -1,6 +1,13 @@
 # VC Affiliations Contribution Guidelines
 
-The VC Twitter affiliations are stored in `vc/vc_twitter_affiliation.json`. Below is an example format using @AlanaDLevin from Variant Fund:
+The VC Twitter affiliations are stored in two files in this directory:
+
+- **`vc/vc_twitter_affiliations.json`** — the user-to-firm edges (one Twitter user_id → array of VC firm Twitter user_ids). The example below shows this file's format.
+- **`vc/vc_firms.json`** — display metadata for each firm referenced by `vc_affiliations[]` (mirrors the `Exchange_Arena/Exchange_Arena.json` pattern). Required fields: `twitter_user_id`, `remarks.twitter_handle`, `remarks.display_name`. Optional: `remarks.fullname`, `remarks.website`. **Every firm Twitter user_id used in `vc_twitter_affiliations.json` MUST have a corresponding entry in `vc_firms.json`.**
+
+## `vc_twitter_affiliations.json` format
+
+Below is an example format using @AlanaDLevin from Variant Fund:
 
 ```json
 [

--- a/vc/vc_firms.json
+++ b/vc/vc_firms.json
@@ -1,0 +1,488 @@
+[
+  {
+    "twitter_user_id": "875103478946775040",
+    "remarks": {
+      "twitter_handle": "1confirmation",
+      "display_name": "1confirmation",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "978008453225496576",
+    "remarks": {
+      "twitter_handle": "1kxnetwork",
+      "display_name": "1kxnetwork",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1182327328061497344",
+    "remarks": {
+      "twitter_handle": "6thManVentures",
+      "display_name": "6thManVentures",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1539681011696603137",
+    "remarks": {
+      "twitter_handle": "a16zcrypto",
+      "display_name": "a16zcrypto",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "909513498652225538",
+    "remarks": {
+      "twitter_handle": "alliancedao",
+      "display_name": "alliancedao",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "2478217117",
+    "remarks": {
+      "twitter_handle": "animocabrands",
+      "display_name": "animocabrands",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "935028743130660864",
+    "remarks": {
+      "twitter_handle": "Arrington_Cap",
+      "display_name": "Arrington_Cap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1483490828848799748",
+    "remarks": {
+      "twitter_handle": "BainCapCrypto",
+      "display_name": "BainCapCrypto",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "819187331777302528",
+    "remarks": {
+      "twitter_handle": "BITKRAFTVC",
+      "display_name": "BITKRAFTVC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "3033323297",
+    "remarks": {
+      "twitter_handle": "blockchaincap",
+      "display_name": "blockchaincap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1192354230763261957",
+    "remarks": {
+      "twitter_handle": "buildwithMV",
+      "display_name": "buildwithMV",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "907349746880319488",
+    "remarks": {
+      "twitter_handle": "CMT_Digital",
+      "display_name": "CMT_Digital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "3344834374",
+    "remarks": {
+      "twitter_handle": "coinfund_io",
+      "display_name": "coinfund_io",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1065847406590214146",
+    "remarks": {
+      "twitter_handle": "CoinSummerLabs",
+      "display_name": "CoinSummerLabs",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1485855043018379266",
+    "remarks": {
+      "twitter_handle": "CsquaredVC",
+      "display_name": "CsquaredVC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1037045241084342272",
+    "remarks": {
+      "twitter_handle": "Delphi_Digital",
+      "display_name": "Delphi_Digital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1173770081295200263",
+    "remarks": {
+      "twitter_handle": "dragonfly_xyz",
+      "display_name": "dragonfly_xyz",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "994440544657928193",
+    "remarks": {
+      "twitter_handle": "ElectricCapital",
+      "display_name": "ElectricCapital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "934061151008251904",
+    "remarks": {
+      "twitter_handle": "fabric_vc",
+      "display_name": "fabric_vc",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1408509930731102214",
+    "remarks": {
+      "twitter_handle": "FactionVC",
+      "display_name": "FactionVC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1383522495664254979",
+    "remarks": {
+      "twitter_handle": "FoliusVentures",
+      "display_name": "FoliusVentures",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "541042800",
+    "remarks": {
+      "twitter_handle": "foundersfund",
+      "display_name": "foundersfund",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1578313885559447553",
+    "remarks": {
+      "twitter_handle": "greenfield_cap",
+      "display_name": "greenfield_cap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "875019401707180032",
+    "remarks": {
+      "twitter_handle": "hack_vc",
+      "display_name": "hack_vc",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "983161646347575296",
+    "remarks": {
+      "twitter_handle": "hashed_official",
+      "display_name": "hashed_official",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1248095683061485568",
+    "remarks": {
+      "twitter_handle": "HashKey_Capital",
+      "display_name": "HashKey_Capital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1022221529763860481",
+    "remarks": {
+      "twitter_handle": "hiFramework",
+      "display_name": "hiFramework",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "856158495367872513",
+    "remarks": {
+      "twitter_handle": "IOSGVC",
+      "display_name": "IOSGVC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1492033549708722177",
+    "remarks": {
+      "twitter_handle": "KuCoinVentures",
+      "display_name": "KuCoinVentures",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "962525753089798144",
+    "remarks": {
+      "twitter_handle": "Lemniscap",
+      "display_name": "Lemniscap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1111529709739765760",
+    "remarks": {
+      "twitter_handle": "LongHashVC",
+      "display_name": "LongHashVC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "2708070367",
+    "remarks": {
+      "twitter_handle": "Maven11Capital",
+      "display_name": "Maven11Capital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1277268771019747328",
+    "remarks": {
+      "twitter_handle": "MechanismCap",
+      "display_name": "MechanismCap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1452366326404583425",
+    "remarks": {
+      "twitter_handle": "mirana",
+      "display_name": "mirana",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1159403859791491072",
+    "remarks": {
+      "twitter_handle": "MoonrockCapital",
+      "display_name": "MoonrockCapital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1341042787798687746",
+    "remarks": {
+      "twitter_handle": "Morningstar_VC",
+      "display_name": "Morningstar_VC",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "883431331098759169",
+    "remarks": {
+      "twitter_handle": "multicoincap",
+      "display_name": "multicoincap",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1315743815316119552",
+    "remarks": {
+      "twitter_handle": "nascentxyz",
+      "display_name": "nascentxyz",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1505018413483057152",
+    "remarks": {
+      "twitter_handle": "nolimithodl",
+      "display_name": "nolimithodl",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1378972938968264713",
+    "remarks": {
+      "twitter_handle": "Not3Lau_Capital",
+      "display_name": "Not3Lau_Capital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "2676374953",
+    "remarks": {
+      "twitter_handle": "OVioHQ",
+      "display_name": "OVioHQ",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "2287471915",
+    "remarks": {
+      "twitter_handle": "PanteraCapital",
+      "display_name": "PanteraCapital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "166765173",
+    "remarks": {
+      "twitter_handle": "paradigm",
+      "display_name": "paradigm",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1131237599173959680",
+    "remarks": {
+      "twitter_handle": "paraficapital",
+      "display_name": "paraficapital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "246158437",
+    "remarks": {
+      "twitter_handle": "polychain",
+      "display_name": "polychain",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1119002171054288896",
+    "remarks": {
+      "twitter_handle": "primitivecrypto",
+      "display_name": "primitivecrypto",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1731748085364113408",
+    "remarks": {
+      "twitter_handle": "reforge_vc",
+      "display_name": "reforge_vc",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1080901534169223168",
+    "remarks": {
+      "twitter_handle": "robotventures",
+      "display_name": "robotventures",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "2972233924",
+    "remarks": {
+      "twitter_handle": "RyzeLabs",
+      "display_name": "RyzeLabs",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1156635271997399042",
+    "remarks": {
+      "twitter_handle": "Sfermion_",
+      "display_name": "Sfermion_",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "971375572902330371",
+    "remarks": {
+      "twitter_handle": "Signum_Capital",
+      "display_name": "Signum_Capital",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1544990371742363648",
+    "remarks": {
+      "twitter_handle": "Superscrypt",
+      "display_name": "Superscrypt",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "956841052563910656",
+    "remarks": {
+      "twitter_handle": "TheSpartanGroup",
+      "display_name": "TheSpartanGroup",
+      "fullname": "",
+      "website": ""
+    }
+  },
+  {
+    "twitter_user_id": "1183940649260847105",
+    "remarks": {
+      "twitter_handle": "variantfund",
+      "display_name": "variantfund",
+      "fullname": "",
+      "website": ""
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `vc/vc_firms.json` — a new file with display metadata for every VC firm referenced by `vc_twitter_affiliations.json:*.vc_affiliations[]`.
- Mirrors the existing `Exchange_Arena/Exchange_Arena.json` schema convention.
- Bootstrap content auto-generated from the 54 distinct firm Twitter user_ids found in `vc_twitter_affiliations.json` on 2026-06-02.
- Updates `vc/README.md` to note the new file exists.

## File format
```json
[
  {
    "twitter_user_id": "1183940649260847105",
    "remarks": {
      "twitter_handle": "variantfund",
      "display_name": "Variant",
      "fullname": "Variant Fund",
      "website": "https://variant.fund"
    }
  }
]
```

- **Required**: `twitter_user_id`, `remarks.twitter_handle`, `remarks.display_name`.
- **Optional**: `remarks.fullname`, `remarks.website`.
- Sorted alphabetically by `remarks.twitter_handle` (case-insensitive) for stable diffs.

## Why
A downstream consumer (Kaito's MSM v8 / Crypto VC arena rebuild) needs human-readable firm names + handles to render the per-firm leaderboard. Without this file, the leaderboard either has to re-issue N Twitter profile lookups per render or shows raw user_ids. Owner reference: see `migration_planner_generator_kit/docs/crypto_vc_arena_migration_design_2026-06-02.md` §4.2.

## Initial values + reviewer ask
- All 54 firms have `display_name` defaulted to `twitter_handle` (e.g., `a16zcrypto`, `paradigm`, `variantfund`). **Reviewers please refine display names to the human-readable form** (e.g., `a16z crypto`, `Paradigm`, `Variant`).
- `fullname` and `website` left blank for all 54 firms; reviewers can fill these per firm as a follow-up or in this PR.

## Integrity invariant
Every Twitter user_id appearing in `vc_twitter_affiliations.json:*.vc_affiliations[]` MUST have a corresponding entry in `vc_firms.json:*.twitter_user_id`. The 54 entries in this PR satisfy this constraint at HEAD; a follow-up CI check could enforce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)