### PR TITLE
Add ARX pre-TGE project

### DIFF
--- a/PreTGE_Project/PreTGE_Project.json
+++ b/PreTGE_Project/PreTGE_Project.json
@@ -1358,5 +1358,13 @@
             "fullname": "KiiChain",
             "twitter_handle": "KiiChainio"
         }
+    },
+    {
+        "ticker": "ARX",
+        "remarks": {
+            "display_ticker": "ARX",
+            "fullname": "Arcium",
+            "twitter_handle": "Arcium"
+        }
     }
 ]


### PR DESCRIPTION
## What changed

Added Arcium (`ARX`) to the Pre-TGE projects dataset.

## Why

This registers the requested pre-TGE project metadata using the repository's existing `ticker` and `remarks` schema.

## Validation

- Validated all repository JSON datasets with `jq empty`
- Confirmed the Pre-TGE project count increased from 170 to 171
- Confirmed `ARX` appears exactly once in `PreTGE_Project/PreTGE_Project.json`