### PR TITLE
[codex] Add PREIPO batch1 public curation list

### DIFF
--- a/preipo_companies/README.md
+++ b/preipo_companies/README.md
@@ -1,0 +1,46 @@
+# Pre-IPO Companies — Contribution Guidelines
+
+This list backs the **Pre-IPO Companies** leaderboard on [Kaito](https://kaito.ai).
+If a company you expect is missing, or an entry has a wrong name or Twitter
+handle, edit `preipo_companies/preipo_companies.json` and open a pull request.
+
+## Format
+
+```json
+[
+    {
+        "symbol": "KRAKEN",
+        "remarks": {
+            "display_name": "Kraken",
+            "fullname": "Payward, Inc.",
+            "twitter_handle": "krakenfx"
+        }
+    }
+]
+```
+
+- **symbol** — the company key used in this public list, usually the company
+  name in uppercase with underscores for spaces. This is not a listed stock
+  ticker.
+- **display_name** — how the company is displayed.
+- **fullname** — the company's official legal or commonly used full name.
+- **twitter_handle** — the company's official X/Twitter handle, without the
+  `@` prefix.
+
+## Scope
+
+Pre-IPO companies are private companies with a credible IPO signal or standing
+pre-IPO market presence. Already-listed companies do not belong in this file.
+
+## Adding or Fixing an Entry
+
+1. Edit `preipo_companies.json` and keep entries sorted by `symbol`.
+2. Open a pull request and explain which Kaito page or company gap prompted the
+   change.
+3. CI validates the JSON format; the Kaito data team reviews.
+
+## What Happens After Merge
+
+This repository collects public suggestions. After a PR is merged, the Kaito
+data team applies the change to Kaito's internal tagging and universe systems;
+product pages update after that ingestion, not instantly.

--- a/preipo_companies/preipo_companies.json
+++ b/preipo_companies/preipo_companies.json
@@ -1,0 +1,114 @@
+[
+    {
+        "symbol": "ANDURIL",
+        "remarks": {
+            "display_name": "Anduril",
+            "fullname": "Anduril Industries, Inc.",
+            "twitter_handle": "anduriltech"
+        }
+    },
+    {
+        "symbol": "ANTHROPIC",
+        "remarks": {
+            "display_name": "Anthropic",
+            "fullname": "Anthropic PBC",
+            "twitter_handle": "AnthropicAI"
+        }
+    },
+    {
+        "symbol": "CANVA",
+        "remarks": {
+            "display_name": "Canva",
+            "fullname": "Canva, Inc.",
+            "twitter_handle": "canva"
+        }
+    },
+    {
+        "symbol": "DATABRICKS",
+        "remarks": {
+            "display_name": "Databricks",
+            "fullname": "Databricks, Inc.",
+            "twitter_handle": "databricks"
+        }
+    },
+    {
+        "symbol": "DISCORD",
+        "remarks": {
+            "display_name": "Discord",
+            "fullname": "Discord Inc.",
+            "twitter_handle": "discord"
+        }
+    },
+    {
+        "symbol": "KALSHI",
+        "remarks": {
+            "display_name": "Kalshi",
+            "fullname": "Kalshi, Inc.",
+            "twitter_handle": "Kalshi"
+        }
+    },
+    {
+        "symbol": "KRAKEN",
+        "remarks": {
+            "display_name": "Kraken",
+            "fullname": "Payward, Inc.",
+            "twitter_handle": "krakenfx"
+        }
+    },
+    {
+        "symbol": "NOTION",
+        "remarks": {
+            "display_name": "Notion",
+            "fullname": "Notion Labs, Inc.",
+            "twitter_handle": "NotionHQ"
+        }
+    },
+    {
+        "symbol": "OPENAI",
+        "remarks": {
+            "display_name": "OpenAI",
+            "fullname": "OpenAI Group PBC",
+            "twitter_handle": "OpenAI"
+        }
+    },
+    {
+        "symbol": "PERPLEXITY",
+        "remarks": {
+            "display_name": "Perplexity",
+            "fullname": "Perplexity AI, Inc.",
+            "twitter_handle": "perplexity_ai"
+        }
+    },
+    {
+        "symbol": "POLYMARKET",
+        "remarks": {
+            "display_name": "Polymarket",
+            "fullname": "Polymarket (Blockratize, Inc.)",
+            "twitter_handle": "Polymarket"
+        }
+    },
+    {
+        "symbol": "REVOLUT",
+        "remarks": {
+            "display_name": "Revolut",
+            "fullname": "Revolut Ltd",
+            "twitter_handle": "Revolut"
+        }
+    },
+    {
+        "symbol": "RIPPLE",
+        "remarks": {
+            "display_name": "Ripple",
+            "fullname": "Ripple Labs, Inc.",
+            "twitter_handle": "Ripple"
+        }
+    },
+    {
+        "symbol": "STRIPE",
+        "remarks": {
+            "display_name": "Stripe",
+            "fullname": "Stripe, Inc.",
+            "twitter_handle": "stripe"
+        }
+    }
+]


### PR DESCRIPTION
## Summary

- Adds `preipo_companies/preipo_companies.json` with the PREIPO Arena batch1 public curation list.
- Adds `preipo_companies/README.md` with the same lightweight contribution pattern used by the other KPDA curation projects.
- Uses 14 companies and keeps the public schema intentionally simple: `symbol` plus `remarks.display_name`, `remarks.fullname`, and `remarks.twitter_handle`.
- Uses current Revolut X handle `Revolut`.

## Validation

- `python3 scripts/validate_datasets.py` reports 0 errors; existing repository warnings are unchanged empty-handle warnings in other datasets.
- Scoped PREIPO assertion: 14 expected symbols, sorted by `symbol`, no `STOCK_ENTITY_*`, required remarks fields present, no `@` prefixes.
- JSON parse: `preipo_companies/preipo_companies.json`.

## Notes

- The public KPDA list no longer carries pipeline state, admission state, topic ownership, or long evidence records.
- DKA topic mapping remains internal and explicit in the held universe insert/runbook: OpenAI, Anthropic, and Perplexity map to existing `AI_ENTITY_*`; the other 11 map to `PREIPO_ENTITY_*`.
- Universe insert is not part of this PR and should wait for owner ACK plus DKA/tagging verification.
- Precision review remains blocked until DKA merge plus tagging/backfill produces `PREIPO_ENTITY_%` rows in ClickHouse.
