### PR TITLE
Add PREIPO Hiive50 batch2 companies

### DIFF
--- a/preipo_companies/preipo_companies.json
+++ b/preipo_companies/preipo_companies.json
@@ -16,11 +16,27 @@
         }
     },
     {
+        "symbol": "APPTRONIK",
+        "remarks": {
+            "display_name": "Apptronik",
+            "fullname": "Apptronik, Inc.",
+            "twitter_handle": "Apptronik"
+        }
+    },
+    {
         "symbol": "CANVA",
         "remarks": {
             "display_name": "Canva",
             "fullname": "Canva, Inc.",
             "twitter_handle": "canva"
+        }
+    },
+    {
+        "symbol": "CRUSOE",
+        "remarks": {
+            "display_name": "Crusoe",
+            "fullname": "Crusoe Energy Systems LLC",
+            "twitter_handle": "CrusoeAI"
         }
     },
     {
@@ -40,6 +56,22 @@
         }
     },
     {
+        "symbol": "FIELD_AI",
+        "remarks": {
+            "display_name": "FieldAI",
+            "fullname": "FieldAI, Inc.",
+            "twitter_handle": "fieldai_"
+        }
+    },
+    {
+        "symbol": "GROQ",
+        "remarks": {
+            "display_name": "Groq",
+            "fullname": "Groq, Inc.",
+            "twitter_handle": "GroqInc"
+        }
+    },
+    {
         "symbol": "KALSHI",
         "remarks": {
             "display_name": "Kalshi",
@@ -53,6 +85,22 @@
             "display_name": "Kraken",
             "fullname": "Payward, Inc.",
             "twitter_handle": "krakenfx"
+        }
+    },
+    {
+        "symbol": "LAMBDA_LABS",
+        "remarks": {
+            "display_name": "Lambda",
+            "fullname": "Lambda Labs, Inc.",
+            "twitter_handle": "LambdaAPI"
+        }
+    },
+    {
+        "symbol": "LIGHTMATTER",
+        "remarks": {
+            "display_name": "Lightmatter",
+            "fullname": "Lightmatter, Inc.",
+            "twitter_handle": "LightmatterCo"
         }
     },
     {
@@ -88,6 +136,22 @@
         }
     },
     {
+        "symbol": "PSIQUANTUM",
+        "remarks": {
+            "display_name": "PsiQuantum",
+            "fullname": "PsiQuantum Corp.",
+            "twitter_handle": "PsiQuantum"
+        }
+    },
+    {
+        "symbol": "REPLIT",
+        "remarks": {
+            "display_name": "Replit",
+            "fullname": "Replit, Inc.",
+            "twitter_handle": "replit"
+        }
+    },
+    {
         "symbol": "REVOLUT",
         "remarks": {
             "display_name": "Revolut",
@@ -101,6 +165,30 @@
             "display_name": "Ripple",
             "fullname": "Ripple Labs, Inc.",
             "twitter_handle": "Ripple"
+        }
+    },
+    {
+        "symbol": "SANDBOXAQ",
+        "remarks": {
+            "display_name": "SandboxAQ",
+            "fullname": "SandboxAQ, Inc.",
+            "twitter_handle": "SandboxAQ"
+        }
+    },
+    {
+        "symbol": "SCALE_AI",
+        "remarks": {
+            "display_name": "Scale AI",
+            "fullname": "Scale AI, Inc.",
+            "twitter_handle": "scale_ai"
+        }
+    },
+    {
+        "symbol": "SHIELD_AI",
+        "remarks": {
+            "display_name": "Shield AI",
+            "fullname": "Shield AI, Inc.",
+            "twitter_handle": "shieldaitech"
         }
     },
     {


### PR DESCRIPTION
## Summary

Adds eleven Hiive50 batch2 companies to `preipo_companies/preipo_companies.json`:

- Apptronik
- Crusoe
- FieldAI
- Groq
- Lambda
- Lightmatter
- PsiQuantum
- Replit
- SandboxAQ
- Scale AI
- Shield AI

Notes:

- Entries are kept sorted by `symbol`.
- This list includes shared-topic companies (`Groq`, `Shield AI`, `Replit`, `Scale AI`) so the PreIPO company universe can reference them without creating duplicate DKA VTM topics.
- DKA VTM additions for the seven new exclusive PreIPO topics are handled in the sibling DKA PR.

## Validation

- `python3 -m json.tool preipo_companies/preipo_companies.json >/dev/null`
- `python3 scripts/validate_datasets.py` -> `0 error(s), 96 warning(s)`
- `git diff --check`

The 96 warnings are existing empty `twitter_handle` warnings in other datasets and are unrelated to this file.
