### PR TITLE
[codex] Add PREIPO Hiive50 batch3 companies

### DIFF
--- a/preipo_companies/preipo_companies.json
+++ b/preipo_companies/preipo_companies.json
@@ -1,5 +1,13 @@
 [
     {
+        "symbol": "1XTECH",
+        "remarks": {
+            "display_name": "1X",
+            "fullname": "1X Technologies AS",
+            "twitter_handle": "1x_tech"
+        }
+    },
+    {
         "symbol": "ANDURIL",
         "remarks": {
             "display_name": "Anduril",
@@ -32,6 +40,14 @@
         }
     },
     {
+        "symbol": "COHERE",
+        "remarks": {
+            "display_name": "Cohere",
+            "fullname": "Cohere Inc.",
+            "twitter_handle": "cohere"
+        }
+    },
+    {
         "symbol": "CRUSOE",
         "remarks": {
             "display_name": "Crusoe",
@@ -48,6 +64,14 @@
         }
     },
     {
+        "symbol": "DATAMINR",
+        "remarks": {
+            "display_name": "Dataminr",
+            "fullname": "Dataminr, Inc.",
+            "twitter_handle": "Dataminr"
+        }
+    },
+    {
         "symbol": "DISCORD",
         "remarks": {
             "display_name": "Discord",
@@ -61,6 +85,14 @@
             "display_name": "FieldAI",
             "fullname": "FieldAI, Inc.",
             "twitter_handle": "fieldai_"
+        }
+    },
+    {
+        "symbol": "GLEAN",
+        "remarks": {
+            "display_name": "Glean",
+            "fullname": "Glean Technologies, Inc.",
+            "twitter_handle": "glean"
         }
     },
     {
@@ -168,6 +200,14 @@
         }
     },
     {
+        "symbol": "SAMBANOVA_SYSTEMS",
+        "remarks": {
+            "display_name": "SambaNova Systems",
+            "fullname": "SambaNova Systems, Inc.",
+            "twitter_handle": "SambaNovaAI"
+        }
+    },
+    {
         "symbol": "SANDBOXAQ",
         "remarks": {
             "display_name": "SandboxAQ",
@@ -197,6 +237,22 @@
             "display_name": "Stripe",
             "fullname": "Stripe, Inc.",
             "twitter_handle": "stripe"
+        }
+    },
+    {
+        "symbol": "VARDA_SPACE_INDUSTRIES",
+        "remarks": {
+            "display_name": "Varda Space Industries",
+            "fullname": "Varda Space Industries, Inc.",
+            "twitter_handle": "VardaSpace"
+        }
+    },
+    {
+        "symbol": "WHATNOT",
+        "remarks": {
+            "display_name": "Whatnot",
+            "fullname": "Whatnot Inc.",
+            "twitter_handle": "Whatnot"
         }
     }
 ]


### PR DESCRIPTION
## Summary
- Add PREIPO batch3 public-list entries for shared AI candidates: 1X, Cohere, Glean, SambaNova Systems.
- Add PREIPO batch3 public-list entries for new exclusive candidates: Varda Space Industries, Whatnot, Dataminr.
- Keep the list sorted by symbol.

## Validation
- `python3 scripts/validate_datasets.py` -> 0 errors, 96 existing warnings.
- `git diff --check` passed.

## Notes
- Shared AI candidates should reuse existing AI_ENTITY topics through PREIPO universe membership; do not create duplicate VTM rows for them.
- New exclusive VTM rows are handled in the paired DKA PR.