### PR TITLE
[codex] Add PREIPO Xiaohongshu and ByteDance companies

### DIFF
--- a/preipo_companies/preipo_companies.json
+++ b/preipo_companies/preipo_companies.json
@@ -32,6 +32,14 @@
         }
     },
     {
+        "symbol": "BYTEDANCE",
+        "remarks": {
+            "display_name": "ByteDance",
+            "fullname": "ByteDance Ltd.",
+            "twitter_handle": "BytedanceTalk"
+        }
+    },
+    {
         "symbol": "CANVA",
         "remarks": {
             "display_name": "Canva",
@@ -253,6 +261,14 @@
             "display_name": "Whatnot",
             "fullname": "Whatnot Inc.",
             "twitter_handle": "Whatnot"
+        }
+    },
+    {
+        "symbol": "XIAOHONGSHU",
+        "remarks": {
+            "display_name": "Xiaohongshu",
+            "fullname": "Xiaohongshu / RedNote",
+            "twitter_handle": "xiaohongshu"
         }
     }
 ]


### PR DESCRIPTION
## Summary

Adds two Pre-IPO Companies registry entries:

- `BYTEDANCE` / ByteDance Ltd. / `BytedanceTalk`
- `XIAOHONGSHU` / Xiaohongshu / RedNote / `xiaohongshu`

This keeps the public KPDA registry aligned with the DKA PreIPO tagging topics for the same two additions.

## Where did you spot this?

- Kaito page / arena: Pre-IPO Companies
- Sector / category: PREIPO company universe

## Checklist

- [x] I edited the right dataset for my suggestion (see the README routing table)
- [x] `ticker` / `symbol` follows the folder README's key format and the file stays sorted by it
- [x] `twitter_handle` is the official account, without the `@` prefix
- [x] `fullname` / `display_name` have no `@` marks
- [x] I am not adding a product/model whose parent company is already listed

## Validation

- `jq empty preipo_companies/preipo_companies.json`
- `python3 scripts/validate_datasets.py` -> `0 error(s), 96 warning(s)`; warnings are existing empty-handle warnings in other datasets
- focused jq checks: symbols unique, symbols sorted, both new handles are non-empty and do not include `@`
- `git diff --check`

## Paired DKA PR

- MetaSearch-IO/DataKnowledgeAsset#3041 adds matching `PREIPO_ENTITY_Xiaohongshu` and `PREIPO_ENTITY_ByteDance` VTM rows.