### PR TITLE
Fix rednote display name

### DIFF
--- a/preipo_companies/preipo_companies.json
+++ b/preipo_companies/preipo_companies.json
@@ -464,10 +464,10 @@
         }
     },
     {
-        "symbol": "XIAOHONGSHU",
+        "symbol": "rednote",
         "remarks": {
-            "display_name": "Xiaohongshu",
-            "fullname": "Xiaohongshu / RedNote",
+            "display_name": "rednote",
+            "fullname": "rednote / Xiaohongshu",
             "twitter_handle": "xiaohongshu"
         }
     }


### PR DESCRIPTION
Update PREIPO company symbol/display fields from Xiaohongshu to rednote.