### PR TITLE
Add new cryptocurrency entry for The Black Bull

### DIFF
--- a/crypto_companies/crypto_companies.json
+++ b/crypto_companies/crypto_companies.json
@@ -528,6 +528,14 @@
         }
     },
     {
+    "ticker": "ANSEM",
+    "remarks": {
+        "display_ticker": "ANSEM",
+        "fullname": "The Black Bull",
+        "twitter_handle": "blknoiz06"
+    }
+    }
+    {
         "ticker": "ANTAUTONOMI",
         "remarks": {
             "display_ticker": "ANT",


### PR DESCRIPTION
# What's changed and what's your intention?

<!-- 1-3 sentences. For additions: who is this company/project and why does it belong on Kaito? -->

## Where did you spot this?

- Kaito page / arena: <!-- e.g. Crypto Companies, AI Companies > Coding Agents, Pre-TGE, Information Markets, Exchange Arena -->
- Sector / category (if any): <!-- e.g. video_gen, DeFi -->

## Checklist

- [ ] I edited the right dataset for my suggestion (see the [README](https://github.com/MetaSearch-IO/KaitoPublicDataKnowledgeAssets/blob/main/README.md) routing table)
- [ ] `ticker` / `symbol` follows the folder README's key format and the file stays **sorted** by it (new curation datasets)
- [ ] `twitter_handle` is the **official** account, without the `@` prefix
- [ ] `fullname` / `display_name` have no `@` marks
- [ ] I am not adding a product/model whose parent company is already listed (AI list — see the [folder README](https://github.com/MetaSearch-IO/KaitoPublicDataKnowledgeAssets/blob/main/ai_companies/README.md) for the standalone-entity exception)
