### PR TITLE
Add QuoteMarkets information market project

### DIFF
--- a/information_markets/information_markets_projects.json
+++ b/information_markets/information_markets_projects.json
@@ -366,5 +366,13 @@
             "fullname": "Outcome",
             "twitter_handle": "Outcomexyz"
         }
+    },
+    {
+        "ticker": "QUOTE",
+        "remarks": {
+            "display_ticker": "QUOTE",
+            "fullname": "QuoteMarkets",
+            "twitter_handle": "quotemarkets"
+        }
     }
 ]


### PR DESCRIPTION
## Summary
- Add `QUOTE` / QuoteMarkets to `information_markets/information_markets_projects.json`
- Set `display_ticker` to `QUOTE` and `twitter_handle` to `quotemarkets`

## Validation
- `python3 scripts/validate_datasets.py` (0 errors; existing warnings for missing twitter handles remain)
- `git diff --check`
