### PR TITLE
Add MagicMarkets to information markets projects list

### DIFF
--- a/information_markets/information_markets_projects.json
+++ b/information_markets/information_markets_projects.json
@@ -366,5 +366,13 @@
             "fullname": "Outcome",
             "twitter_handle": "Outcomexyz"
         }
+    },
+    {
+        "ticker": "MAGICMARKETS",
+        "remarks": {
+            "display_ticker": "MAGICMARKETS",
+            "fullname": "MagicMarkets",
+            "twitter_handle": "magicmarkets"
+        }
     }
 ]


### PR DESCRIPTION
### Which page

Kaito Mindshare Arena, Crypto vertical, Information Markets arena (`kaito.ai/mindshare-arena/companies`). MagicMarkets is missing from that treemap, so it is absent from `information_markets/information_markets_projects.json`.

### What MagicMarkets is

A peer-to-peer prediction market exchange for sports, with zero fees and zero commission. Traders back and lay against each other rather than against a house. Site: https://magicmarkets.com. X: https://x.com/magicmarkets

It is also listed on DefiLlama, with a public dataset at `dune.magicmarkets.data`.

### The entry

```json
{
    "ticker": "MAGICMARKETS",
    "remarks": {
        "display_ticker": "MAGICMARKETS",
        "fullname": "MagicMarkets",
        "twitter_handle": "magicmarkets"
    }
}
```

MagicMarkets is pre-TGE with no token, so the ticker uses the project name in uppercase, per the folder README. Please curate the display ticker if you prefer a shorter form.

### Checks

`python3 scripts/validate_datasets.py` reports 0 errors. The diff adds 8 lines and changes nothing else.

Generated with [Claude Code](https://claude.com/claude-code)